### PR TITLE
Bugfix - Incorrect integer value

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -7,7 +7,8 @@ $cols = [
             'type' => 'select',
             'renderType' => 'selectSingle',
             'foreign_table' => 'tx_intpark_domain_model_park',
-            'foreign_table_where' => 'AND {#tx_intpark_domain_model_park}.{#deleted} = 0 AND {#tx_intpark_domain_model_park}.{#hidden} = 0'
+            'foreign_table_where' => 'AND {#tx_intpark_domain_model_park}.{#deleted} = 0 AND {#tx_intpark_domain_model_park}.{#hidden} = 0',
+            'default' => 0
         ],
     ],
     'tx_intpark_zoom'=> [


### PR DESCRIPTION
Bug found in TYPO3 9.5.31 Installation, if you try to copy&paste any contentelement on ony page.

This bugfix work for me. Please add it your maintainer repo. Thansk.

```

1: Attempt to insert record on page '[root-level]' (0) where this table, tt_content, is not allowed
2: SQL error: 'Incorrect integer value: '' for column `myTypo3Project`.`tt_content`.`tx_intpark_park` at row 1' 
```